### PR TITLE
Validate language codes and values

### DIFF
--- a/garnett/fields.py
+++ b/garnett/fields.py
@@ -45,7 +45,10 @@ def blank_fallback(field, obj):
 
 
 def validate_translation_dict(all_ts):
-    """Validate that translation dict maps valid lang code to string"""
+    """Validate that translation dict maps valid lang code to string
+
+    Could be used as model or form validator
+    """
     if not isinstance(all_ts, dict):
         raise exceptions.ValidationError("Invalid value assigned to translatable field")
 
@@ -169,9 +172,11 @@ class TranslatedFieldBase(JSONField):
         setattr(cls, get_property_name(), translations)
 
     def run_validators(self, values):
-        if values in self.empty_values:
-            return
+        # Run validators on JSON field
+        # Doing this first ensures we have valid type for checks below
+        super().run_validators(values)
 
+        # Run validators on sub field
         errors = []
         for value in values.values():
             for v in self.field.validators:

--- a/tests/library_app/settings.py
+++ b/tests/library_app/settings.py
@@ -16,7 +16,7 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-GARNETT_TRANSLATABLE_LANGUAGES = ["en", "fr", "sjn", "tlh"]
+GARNETT_TRANSLATABLE_LANGUAGES = ["en", "de", "fr", "sjn", "tlh"]
 GARNETT_DEFAULT_TRANSLATABLE_LANGUAGE = "en"
 
 # Quick-start development settings - unsuitable for production

--- a/tests/tests/test_assignment.py
+++ b/tests/tests/test_assignment.py
@@ -23,7 +23,7 @@ class TestFieldAssignment(TestCase):
         self.book_data = book_data.copy()
         Book.objects.create(**self.book_data)
 
-    def test_validation(self):
+    def test_max_length_validation(self):
         book = Book.objects.first()
         with set_field_language("en"):
             book.title = "A short value"

--- a/tests/tests/test_middleware.py
+++ b/tests/tests/test_middleware.py
@@ -1,10 +1,48 @@
-from django.test import Client, TestCase
+from django.test import Client, TestCase, RequestFactory
+from django.http import HttpResponse, Http404
+
+from garnett.middleware import (
+    TranslationContextMiddleware,
+    TranslationContextNotFoundMiddleware,
+)
+from garnett.utils import get_current_language
 
 
 class TestTranslationContextMiddleware(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = TranslationContextMiddleware(lambda r: HttpResponse("Nice"))
+        self.not_found_middleware = TranslationContextNotFoundMiddleware(
+            lambda r: HttpResponse("Nice")
+        )
+
     def test_sets_language_context(self):
         c = Client()
         response = c.get("/")
         self.assertEqual(response.status_code, 200)
         self.assertTrue("garnett_languages" in response.context.keys())
         self.assertTrue("garnett_current_language" in response.context.keys())
+
+    def test_translation_middleware_sets_language(self):
+        def test_view(request):
+            lang = get_current_language()
+            self.assertEqual(lang, "de")
+            return HttpResponse("Nice")
+
+        middleware = TranslationContextMiddleware(test_view)
+        middleware(self.factory.get("/home?glang=de"))
+
+    def test_translation_middleware_sets_cookie(self):
+        response = self.middleware(self.factory.get("/home?glang=de"))
+        self.assertIn("GARNETT_LANGUAGE_CODE", response.cookies)
+        self.assertEqual(response.cookies["GARNETT_LANGUAGE_CODE"].value, "de")
+
+    def test_not_found_middleware_valid_lang(self):
+        """Test that the not found middleware returns response when given valid language"""
+        response = self.not_found_middleware(self.factory.get("/home?glang=de"))
+        self.assertEqual(response.content, b"Nice")
+
+    def test_not_found_middleware_invalid_lang(self):
+        """Test that the not found middleware 404's when given invalid language"""
+        with self.assertRaises(Http404):
+            self.not_found_middleware(self.factory.get("/home?glang=notalang"))


### PR DESCRIPTION
~~Need to decide whether to move this validation into a django validator object, this would make the
field work the same as other model fields and allow for validation on save while catching django's
validation exception.~~

Will write tests after deciding on the above

This fixes #14 and fixes #7
