### PR TITLE
Add publish to pypi github action

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,4 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - uses: psf/black@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
           --health-retries 10
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: 3.8
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish
+on:
+  release:
+    types:
+      - published
+
+jobs:
+
+  pypi:
+    name: Publish to pypi
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install poetry
+        run: pip install poetry
+      - name: Build
+        run: poetry build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.4.1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Will need to make a pypi token and add it as a github secret for this to work. The action is
triggered on github releases.

This closes #11
