### PR TITLE
Remove update of admin field defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Advanced Settings (you probably don't need to adjust these)
 ## Warnings
 
 * `contains == icontains` For cross database compatibility reasons this library treats `contains` like `icontains`. I don't know why - https://www.youtube.com/watch?v=PgGNWRtceag
+* Due to how django sets admin form fields you will not get the admin specific widgets like
+  `AdminTextAreaWidget` on translated fields in the django admin site by default. They can however
+  be specified explicitly on the corresponding model form
 
 need to run tests like this for now: PYTHONPATH=../ ./manage.py shell
 

--- a/garnett/fields.py
+++ b/garnett/fields.py
@@ -272,11 +272,3 @@ Translated = TranslatedField
 
 # Import lookups here so that they are registered by just importing the field
 from garnett import lookups
-
-
-# Add widget for django admin
-FORMFIELD_FOR_DBFIELD_DEFAULTS.update(
-    {
-        TranslatedField: {"widget": widgets.AdminTextareaWidget},
-    }
-)


### PR DESCRIPTION
A caveat was also added to the readme. The defaults update was removed
since we are now using a single class to wrap sub fields and this would
use the text area for any translated field.