### PR TITLE
Create separate session caching middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ Django Garnett uses the python `langcodes` to determine more information about t
         * `garnett.selector.query`: Checks the `GARNETT_QUERY_PARAMETER_NAME` for a language to display
         * `garnett.selector.cookie`: Checks for a cookie called `GARNETT_LANGUAGE_CODE` for a language to display.
             Note: you cannot change this cookie name.
+        * `garnett.selector.session`: Checks for a session key `GARNETT_LANGUAGE_CODE` for a language to display.
+            Note: you cannot change this key name.
         * `garnett.selector.header`: Checks for a HTTP Header called `X-Garnett-Language-Code` for a language to display.
             Note: you cannot change this Header name.
-        * `garnett.selector.browser`: Uses Django's `get_language` to get the users browser/UI language as determined by Django.
+        * `garnett.selector.browser`: Uses Django's `get_language` function to get the users browser/UI language [as determined by Django][django-how].
     * For example, if you only want to check headers and cookies in that order, set this to `['garnett.selector.header', 'garnett.selector.cookie']`.
     * default: `['garnett.selector.query', 'garnett.selector.cookie', 'garnett.selector.header']`
 * `GARNETT_QUERY_PARAMETER_NAME`:
@@ -200,3 +202,4 @@ Advanced Settings (you probably don't need to adjust these)
 need to run tests like this for now: PYTHONPATH=../ ./manage.py shell
 
 [term-language-code]: https://docs.djangoproject.com/en/3.1/topics/i18n/#term-language-code
+[django-how]: https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#how-django-discovers-language-preference

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ You can also add a few value adds:
 
     * (Future addition) You want to capture the garnett language in a context variable available in views, and want to redirect to the default language if the user requests an invalid language use: `garnett.middleware.TranslationContextRedirectDefaultMiddleware`
 
+    * If you want to cache the current language in session storage use `garnett.middleware.TranslationCacheMiddleware` after one of the above middleware (this is useful with the session selector mentioned below)
+
 8. (Optional) Add the `garnett` app to your `INSTALLED_APPS` to use garnett's template_tags. If this is installed before `django.contrib.admin` it also include a language switcher in the Django Admin Site.
 
 9. (Optional) Add a template processor:

--- a/garnett/selectors.py
+++ b/garnett/selectors.py
@@ -11,6 +11,10 @@ def cookie(request):
     return request.COOKIES.get("GARNETT_LANGUAGE_CODE", None)
 
 
+def session(request):
+    return request.session.get("GARNETT_LANGUAGE_CODE", None)
+
+
 def header(request):
     return request.META.get("HTTP_X_GARNETT_LANGUAGE_CODE", None)
 

--- a/tests/tests/test_middleware.py
+++ b/tests/tests/test_middleware.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse, Http404
 from garnett.middleware import (
     TranslationContextMiddleware,
     TranslationContextNotFoundMiddleware,
+    TranslationCacheMiddleware,
 )
 from garnett.utils import get_current_language
 
@@ -32,11 +33,6 @@ class TestTranslationContextMiddleware(TestCase):
         middleware = TranslationContextMiddleware(test_view)
         middleware(self.factory.get("/home?glang=de"))
 
-    def test_translation_middleware_sets_cookie(self):
-        response = self.middleware(self.factory.get("/home?glang=de"))
-        self.assertIn("GARNETT_LANGUAGE_CODE", response.cookies)
-        self.assertEqual(response.cookies["GARNETT_LANGUAGE_CODE"].value, "de")
-
     def test_not_found_middleware_valid_lang(self):
         """Test that the not found middleware returns response when given valid language"""
         response = self.not_found_middleware(self.factory.get("/home?glang=de"))
@@ -46,3 +42,22 @@ class TestTranslationContextMiddleware(TestCase):
         """Test that the not found middleware 404's when given invalid language"""
         with self.assertRaises(Http404):
             self.not_found_middleware(self.factory.get("/home?glang=notalang"))
+
+
+class TestTranslationCacheMiddleware(TestCase):
+    def setUp(self):
+        self.middleware = TranslationCacheMiddleware(lambda r: HttpResponse("Nice"))
+        self.factory = RequestFactory()
+
+    def test_cache_middleware_sets_session_value(self):
+        request = self.factory.get("/home")
+        request.garnett_language = "fr"
+        request.session = {}
+        self.middleware(request)
+        self.assertIn("GARNETT_LANGUAGE_CODE", request.session)
+        self.assertEqual(request.session["GARNETT_LANGUAGE_CODE"], "fr")
+
+    def test_cache_middleware_fails_safely(self):
+        """Test that the cache middleware still returns response if no session"""
+        response = self.middleware(self.factory.get("/home"))
+        self.assertEqual(response.content, b"Nice")


### PR DESCRIPTION
Previously the middleware was setting a cookie to cache the language value. This was split into a new middleware so that users can choose whether or not to have the value cached as that may not be expected behaviour. 

For example if the query and cookie selectors are enabled passing a query param to a page used to not only set the language for that request, but all future requests since the cookie had been set.

The cache also now uses session storage so the user has more control over how it is stored.

This closes #25 